### PR TITLE
Style User Account pages

### DIFF
--- a/app/assets/stylesheets/application/_variables.sass
+++ b/app/assets/stylesheets/application/_variables.sass
@@ -19,6 +19,7 @@ $transition-duration: 250ms
 $light_gray:      #f3f2f4
 $medium_gray:     #cccccc
 $dark_gray:       #333
+$inactive_gray:   #eae6d9
 
 $color_solarized_base03:   #002b36 //  8/4 brblack  234 #1c1c1c
 $color_solarized_base02:   #073642 //  0/4 black    235 #262626

--- a/app/assets/stylesheets/pages/users.css.sass
+++ b/app/assets/stylesheets/pages/users.css.sass
@@ -1,0 +1,18 @@
+@import compass/css3/hyphenation
+@import application/variables
+@import application/mixins
+
+.btn.btn-block.disabled
+  color: $color_solarized_base1
+
+.btn-group
+  .btn
+    color: $color_solarized_base1
+
+  .active
+    background-color: $color_solarized_green
+    color: $inactive_gray
+    text-shadow: none
+
+    &:hover
+      color: $inactive_gray

--- a/app/helpers/authorization_helper.rb
+++ b/app/helpers/authorization_helper.rb
@@ -2,16 +2,16 @@ module AuthorizationHelper
   def not_authorized_message(action, object)
     case action
     when :update, :vet, :destroy, :edit, :pick
-      _('Sorry, you may not %{verb} this %{object}.') % { verb: action, object: _(object.class.name.downcase) }
+      _('Sorry, you may not %{verb} this %{object}.') % { verb: action, object: _(object.class.name.gsub('::', ' ').downcase) }
     when :update_admin
-      _('Sorry, you may not %{verb} this %{object}.') % { verb: 'update', object: _(object.class.name.downcase) }
+      _('Sorry, you may not %{verb} this %{object}.') % { verb: 'update', object: _(object.class.name.gsub('::', ' ').downcase) }
     when :vote
       ( object.kind_of?(Idea) ?
         _('Sorry, you may not endorse this %{object}.') :
         _('Sorry, you may not vote for this %{object}.')
-      ) % { object: _(object.class.name.downcase) }
+      ) % { object: _(object.class.name.gsub('::', ' ').downcase) }
     when :create, :new
-      _('Sorry, you may not create %{class}.') % { class: _(object.name.downcase.pluralize) }
+      _('Sorry, you may not create %{class}.') % { class: _(object.name.gsub('::', ' ').downcase.pluralize) }
     else
       raise ArgumentError
       raise ArgumentError, 'unknown action'


### PR DESCRIPTION
This PR aims to fix two issues:

1). Hovering over a user role used to display an error message with "you may not create user::roles".
2). Improving the visibility of active user roles.

Very open to feedback as this may not be the best fit for the style of the site.

![screen shot 2013-07-27 at 12 50 32](https://f.cloud.github.com/assets/950333/866814/be9ec128-f6b5-11e2-88f1-5ab66a2ad705.png)
