### PR TITLE
Return points to backers of winning ideas

### DIFF
--- a/config/initializers/_settings.rb
+++ b/config/initializers/_settings.rb
@@ -22,7 +22,7 @@ configatron.app_fab.karma.idea.commenter.picked  = +1
 configatron.app_fab.karma.idea.commenter.live    = +1
 
 configatron.app_fab.karma.idea.backer.picked     = +1
-configatron.app_fab.karma.idea.backer.live       = +1
+configatron.app_fab.karma.idea.backer.live       = +10
 
 configatron.app_fab.vettings_needed    = 2
 configatron.app_fab.votes_needed       = 2

--- a/spec/observers/karma/idea_observer_spec.rb
+++ b/spec/observers/karma/idea_observer_spec.rb
@@ -54,7 +54,7 @@ describe Karma::IdeaObserver do
     it 'all backers gains karma' do
       backer = User.make!
       idea.votes.make! user: backer
-      lambda { idea.deliver» }.should change { backer.reload.karma }.by(1)
+      lambda { idea.deliver» }.should change { backer.reload.karma }.by(10)
     end
   end
 end


### PR DESCRIPTION
As per Issue #127 users that back an idea can receive their karma back
once the idea has gone live. This should encourage people to vote more
often and for ideas they like and believe have a chance of being
implemented. This should discourage vote spamming through a limited
amount of votes while still rewarding users for their involvement.

I have just changed it so that you receive the same amount of points
back as you already get rewarded one point once the idea gets picked
and this keeps the mechanic symmetric.

I think 1 point should be more or less enough for just backing an idea.
I would definitely agree with increasing the picked value for backers as 
it may not be too fair to give both them and commenters 1 point.
