### PR TITLE
Do not auto-bookmark submitted ideas for PMs

### DIFF
--- a/app/observers/bookmark_observer.rb
+++ b/app/observers/bookmark_observer.rb
@@ -4,6 +4,7 @@ class BookmarkObserver < ActiveRecord::Observer
 
   def after_create(record)
     return true unless record.kind_of?(Idea)
+    return true if record.author.plays? :product_manager
     _create_bookmark_for(record, record.author)
   end
 

--- a/spec/observers/bookmark_observer_spec.rb
+++ b/spec/observers/bookmark_observer_spec.rb
@@ -9,6 +9,17 @@ describe BookmarkObserver do
         Idea.make! author:user
       }.should change { user.bookmarks.count }.by(1)
     end
+
+    context 'user is a PM' do
+      before { user.plays! :product_manager }
+
+      it 'bookmarks it' do
+        lambda {
+          Idea.make! author:user
+        }.should_not change { user.bookmarks.count }
+      end
+
+    end
   end
 
   context 'when a user comments on an idea' do

--- a/spec/services/bookmark_cleanup_service_spec.rb
+++ b/spec/services/bookmark_cleanup_service_spec.rb
@@ -5,7 +5,7 @@ describe BookmarkCleanupService do
 
   subject { described_class.new }
   let(:perform) { subject.run }
-  let(:idea) { Idea.make!(:signed_off) }
+  let(:idea) { Idea.make!(:signed_off, author: User.make!) }
 
   it 'delete bookmarks for old live ideas' do
     Timecop.travel(2.weeks.ago) do


### PR DESCRIPTION
If user has a _Product Manager_ role do not bookmark new ideas.

I head to change BookmarkCleanupService spec because of idea blueprint reuses last user for its author and it often happens to be a product manager. Meaning, that for those ideas no bukmarks would be created in the first place.
