### PR TITLE
Links on search results [fixes #199]

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,7 +6,7 @@ class SearchController < ApplicationController
 
   def index
     @search = Search.new(
-      scope: current_account.ideas, 
+      scope: current_account.ideas,
       query: params[:search].fetch(:query, nil))
   end
 end

--- a/app/views/ideas/_idea_maxi.html.haml
+++ b/app/views/ideas/_idea_maxi.html.haml
@@ -12,7 +12,7 @@
   - classes = [idea.state_machine.state_name, (muted_details && 'af-mutable-content')]
   .af-drop-area
   .idea.idea-maxi.af-drop-hilite{ class:classes }
-    
+
     .meta.top.af-mutable
       = render 'ideas/idea_rating', idea:idea
       .category.muted.pull-left.pull-left-spaced

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -1,5 +1,5 @@
 - @search.ideas.each do |idea|
-  = render partial: 'ideas/idea_maxi', locals: { :idea => idea }
+  = render partial: 'ideas/idea_maxi', locals: { idea: idea, title_link: true }
 
 - if @search.ideas.empty?
   %h3.text-center No ideas matches #{@search.query.inspect}


### PR DESCRIPTION
The normal `ideas/index` had a slew of dependencies so this was the easiest path to solving the issue
