### PR TITLE
Separate karma from user's name with parens

### DIFF
--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -53,8 +53,9 @@
               = link_to path, title: s_('Tooltip|This is you!<br/>Click here to see or edit your profile.<br/>The number next to your name shows the "karma" points you can spend to vote on ideas. Gain more points as you participate!'), :'data-placement' => 'bottom' do
                 %span.first-name= current_login.first_name
                 %span.karma
-                  %span.figure= number_with_delimiter current_user.karma
-                  = user_karma_symbol
+                  = surround '(', ')' do
+                    %span.figure= number_with_delimiter current_user.karma
+                    = user_karma_symbol
             = content_tag_with_path_checking(:li, controller: 'notifications', action: 'index', html: { class:'inbox', title: s_('Tooltip|Your number of unread notifications. Click to view them'), :'data-placement' => 'left' }) do |path|
               = link_to path, class: 'notifications' do
                 - count = current_user.notifications.unread.count

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -29,8 +29,9 @@
           = user.first_name
           - if show_karma
             %span.karma
-              = number_with_delimiter user.karma
-              = user_karma_symbol
+              = surround '(', ')' do
+                = number_with_delimiter user.karma
+                = user_karma_symbol
     - if link_target
       = link_to link_target, link_options do
         = body

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -4,7 +4,7 @@
 -# link     (boolean, default true)
 -# avatar   (boolean or integer, default false)
 -# classes  (string, default none)
-= cached_fragment(disabled:false, resource:User, id:user.id, v:8, key:[user.login.updated_at, user.updated_at, *local_assigns.values_at(:name, :avatar, :karma, :classes, :link), can?(:read, user)]) do
+= cached_fragment(disabled:false, resource:User, id:user.id, v:9, key:[user.login.updated_at, user.updated_at, *local_assigns.values_at(:name, :avatar, :karma, :classes, :link), can?(:read, user)]) do
 
   :ruby
     show_avatar    = !!local_assigns.fetch(:avatar,  true)


### PR DESCRIPTION
Minor cosmetic fix. Surrounds karma points with parens, to separate it from the user's name.

Changes in the following places:
- Nav link in header
- Users list page

![screen shot 2014-05-19 at 12 11 57 pm](https://cloud.githubusercontent.com/assets/84005/3010901/c590457a-df20-11e3-9de5-9e30a3a08fab.png)
