### PR TITLE
[Fixes #118]  Prevents self-vetting by author

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -50,7 +50,10 @@ class Ability
     # Sizing / Vetting
     if user.plays?(:product_manager, :architect)
       can :size,     Idea
-      can :create,   Vetting
+      can :create,   Vetting do |vetting|
+        vetting.idea.author_id != user.id
+      end
+
       can :destroy,  Vetting do |r|
         r.user_id == user.id && r.recently_created?
       end

--- a/features/ideas/vetting.feature
+++ b/features/ideas/vetting.feature
@@ -6,6 +6,7 @@ Feature: Vetting ideas
   Background:
     Given a product manager named "Peter"
     And an architect named "Archie"
+    And a submitter named "Yoda"
     And a sized idea "Solo, make it so"
     And "Archie" has vetted the idea
 

--- a/features/ideas/vetting.feature
+++ b/features/ideas/vetting.feature
@@ -32,7 +32,12 @@ Feature: Vetting ideas
     When I sign in as "Archie"
     Then I cannot vet the idea
 
-
+  Scenario: Should not be able to vet idea if I submitted it
+    Given I sign in as "Peter"
+    And I am also a submitter
+    And I submit an idea "A flying car"
+    Then the idea should be submitted
+    And I cannot vet the idea
 
 
 
@@ -43,3 +48,4 @@ Feature: Vetting ideas
 # Vetting given a sized idea can be created by an architect
 # Vetting given a sized idea can only be done once by a PM
 # Vetting given a sized idea cannot be created by other roles
+# Vetting given a sized idea cannot be vetted by the submitter

--- a/features/step_definitions/devise_steps.rb
+++ b/features/step_definitions/devise_steps.rb
@@ -16,6 +16,13 @@ Given /^an? (.*) named "(\w+)"$/ do |role, first_name|
   Mentions[User] = user
 end
 
+Given /^I am also a (.*)$/ do |role|
+  login = Mentions[Login]
+  user  = login.users.first
+  role_sym = role.split.join('_').to_sym
+  user.plays! role_sym
+end
+
 Given /^I sign in as "(\w+)"$/ do |first_name|
   login = Login.where(first_name: first_name).first
   visit '/session/sign_out'


### PR DESCRIPTION
Fixing this required the following changes too:
- Add a step def to devise steps that allows adds another role to a user
- Add another user in the vetting scenarios to make sure that the idea being tested is authored by a separate user
